### PR TITLE
:dizzy_face: Use Trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: node_js
 node_js:
   - node


### PR DESCRIPTION
Currently the default image used in the Travis build is precise.
This image doesn't have the correct compiler to rebuild the node-sass
package. There are two options:
* [Install a compatabile
compiler](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Node.js-v4-(or-io.js-v3)-compiler-requirements)
* [Use a Trusty
image](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Node.js-v4-(or-io.js-v3)-compiler-requirements)

I've gone for the easier - routing to the Trusty image.