### PR TITLE
:link: Fruitiger now served on 'assets.nhs.uk'

### DIFF
--- a/app/styles/environment/settings/_fonts.scss
+++ b/app/styles/environment/settings/_fonts.scss
@@ -1,1 +1,1 @@
-@import url("https://assets.nhs.uk/fonts/nhsuk-fonts.css");
+@import url("https://assets.nhs.uk/fonts/nhsuk-fonts-1.0.0.css");

--- a/app/styles/environment/settings/_fonts.scss
+++ b/app/styles/environment/settings/_fonts.scss
@@ -1,1 +1,1 @@
-@import url("https://fast.fonts.net/cssapi/0985eb4d-eec4-488b-baa4-22fe85c5ce32.css");
+@import url("https://assets.nhs.uk/fonts/nhsuk-fonts.css");


### PR DESCRIPTION
## Description
Fruitiger font is now stored on 'assets.nhs.uk'. Therefore the library will link to there rather that `fonts.com`