### PR TITLE
:wrench: Helper for image urls

### DIFF
--- a/app/styles/components/_global-footer.scss
+++ b/app/styles/components/_global-footer.scss
@@ -1,5 +1,6 @@
 @import "../environment/settings/colours";
 @import "../environment/settings/typography";
+@import "../environment/tools/functions/asset-urls";
 
 .global-footer {
   background-color: $nhs-blue;
@@ -30,7 +31,7 @@
   }
 
   &:before {
-    background: url("images/logotype-nhs-colour.png") no-repeat;
+    background: image-url("logotype-nhs-colour.png") no-repeat;
     background-size: contain;
     content: "";
     display: block;
@@ -46,7 +47,7 @@
     @media
       (-webkit-min-device-pixel-ratio: 2),
       (min-resolution: 192dpi) {
-      background-image: url("images/logotype-nhs-colour@2x.png");
+      background-image: image-url("logotype-nhs-colour@2x.png");
       background-size: 79px 32px;
     }
   }

--- a/app/styles/components/_global-header.scss
+++ b/app/styles/components/_global-header.scss
@@ -1,6 +1,7 @@
 @import "../environment/settings/colours";
 @import "../environment/tools/mixins/layout";
 @import "../environment/tools/mixins/typography";
+@import "../environment/tools/functions/asset-urls";
 
 .global-header {
   background-color: $white;
@@ -20,7 +21,7 @@
 }
 
 .global-header__link {
-  background: url("images/logotype-nhs-colour__reverse.png") no-repeat;
+  background: image-url("logotype-nhs-colour__reverse.png") no-repeat;
   background-size: contain;
   display: block;
   height: 32px;
@@ -30,7 +31,7 @@
   @media
     (-webkit-min-device-pixel-ratio: 2),
     (min-resolution: 192dpi) {
-    background-image: url("images/logotype-nhs-colour__reverse@2x.png");
+    background-image: image-url("logotype-nhs-colour__reverse@2x.png");
     background-size: 79px 32px;
   }
 

--- a/app/styles/environment/tools/functions/_asset-urls.scss
+++ b/app/styles/environment/tools/functions/_asset-urls.scss
@@ -1,0 +1,9 @@
+
+// Base path for images
+// Should not include a trailing slash
+$images-path: "images" !default;
+
+// Returns a url with prefixed images-path
+@function image-url($file) {
+  @return url($images-path + "/" + $file);
+}

--- a/app/styles/environment/tools/functions/_index.scss
+++ b/app/styles/environment/tools/functions/_index.scss
@@ -1,2 +1,3 @@
 @import "colour";
 @import "typography";
+@import "asset-urls";


### PR DESCRIPTION
Allow the images path ($images-path) to be overidden by implementors of this library

Not all projects that use this library will serve images from `/images`.
In fact is is more likely to be something like `/some-path/frontend-library/app/assets/images`

All usages of `url(...)` for images (4 counts) has been replaced with `image-url(...)`
